### PR TITLE
changed NOMADS protocol to HTTPS from HTTP

### DIFF
--- a/R/composeURL.R
+++ b/R/composeURL.R
@@ -97,7 +97,7 @@ urlMG <- function(var, day, run, spatial, timeFrame, resolution, ...){
 ##################################################################
 urlGFS <- function(var, day, run, spatial, timeFrame, vertical, ...) {
     Ym <- format(day, format='%Y%m')
-    mainURL <- 'http://nomads.ncdc.noaa.gov/thredds/ncss/grid/gfs-004/'
+    mainURL <- 'https://nomads.ncdc.noaa.gov/thredds/ncss/grid/gfs-004/'
     run <- paste0(run, '00')
     timeFrame <- sprintf('%03d', timeFrame)
     URL0 <- paste0(mainURL, Ym, '/', ymd(day), '/',
@@ -118,11 +118,11 @@ urlNAM <- function(var, day, run, spatial, timeFrame, vertical, ...) {
     Ym <- format(day, format='%Y%m')
     ## NAM stores the last year results under the category "Near Real-Time"
     if (today - day < 365) {
-        mainURL <- 'http://nomads.ncdc.noaa.gov/thredds/ncss/grid/nam218/'
+        mainURL <- 'https://nomads.ncdc.noaa.gov/thredds/ncss/grid/nam218/'
         servId <- 'nam_218'
     } else {
         ## Previous results can be found under "Analysis only"
-        mainURL <- 'http://nomads.ncdc.noaa.gov/thredds/ncss/grid/namanl/'
+        mainURL <- 'https://nomads.ncdc.noaa.gov/thredds/ncss/grid/namanl/'
         servId <- 'namanl_218'
     }
 
@@ -147,7 +147,7 @@ urlNAM <- function(var, day, run, spatial, timeFrame, vertical, ...) {
 ##################################################################
 urlRAP <- function(var, day, run, spatial, timeFrame, vertical, ...) {
     Ym <- format(day, format='%Y%m')
-    mainURL <- 'http://nomads.ncdc.noaa.gov/thredds/ncss/grid/rap130/'
+    mainURL <- 'https://nomads.ncdc.noaa.gov/thredds/ncss/grid/rap130/'
     run <- paste0(run, '00')
     timeFrame <- sprintf('%03d', timeFrame)
     URL0 <- paste0(mainURL, Ym, '/', ymd(day), '/',

--- a/R/composeURL.R
+++ b/R/composeURL.R
@@ -97,7 +97,7 @@ urlMG <- function(var, day, run, spatial, timeFrame, resolution, ...){
 ##################################################################
 urlGFS <- function(var, day, run, spatial, timeFrame, vertical, ...) {
     Ym <- format(day, format='%Y%m')
-    mainURL <- 'https://nomads.ncdc.noaa.gov/thredds/ncss/grid/gfs-004/'
+    mainURL <- 'https://nomads.ncdc.noaa.gov/thredds/wcs/gfs-004/'
     run <- paste0(run, '00')
     timeFrame <- sprintf('%03d', timeFrame)
     URL0 <- paste0(mainURL, Ym, '/', ymd(day), '/',

--- a/R/grepVar.R
+++ b/R/grepVar.R
@@ -7,7 +7,7 @@ grepVar <- function(x, service, day = Sys.Date() - 15, complete = FALSE)
     wcsURL <- paste0(gsub('ncss/grid', 'wcs', serviceURL),
                      '?service=WCS&version=1.0.0&request=GetCapabilities')
 
-    download.file(wscURL, "./temp.xml", method = "wget", quiet = TRUE)
+    download.file(wcsURL, "./temp.xml", method = "wget", quiet = TRUE)
     wcs <- xmlParse("./temp.xml")
     #wcs <- xmlParse(wcsURL)
     doc <- xmlRoot(wcs)

--- a/R/grepVar.R
+++ b/R/grepVar.R
@@ -7,7 +7,9 @@ grepVar <- function(x, service, day = Sys.Date() - 15, complete = FALSE)
     wcsURL <- paste0(gsub('ncss/grid', 'wcs', serviceURL),
                      '?service=WCS&version=1.0.0&request=GetCapabilities')
 
-    wcs <- xmlParse(wcsURL)
+    download.file(wscURL, "./temp.xml", method = "wget", quiet = TRUE)
+    wcs <- xmlParse("./temp.xml")
+    #wcs <- xmlParse(wcsURL)
     doc <- xmlRoot(wcs)
     content <- xmlChildren(doc)
     meta <- content[["ContentMetadata"]]


### PR DESCRIPTION
Following Federal government policy (2016-12-23), NOMADS web services have transitioned to use of HTTPS and HSTS.